### PR TITLE
fix: Added error messages instead of recurring while hashing.

### DIFF
--- a/src/main/java/io/deephaven/hash/KHash.java
+++ b/src/main/java/io/deephaven/hash/KHash.java
@@ -210,6 +210,22 @@ public abstract class KHash implements Cloneable {
       // if we've exhausted the free spots, rehash to the same capacity,
       // which will free up any stale removed slots for reuse.
       int newCapacity = _size > _maxSize ? PrimeFinder.nextPrime(capacity() << 1) : capacity();
+
+      // Before rehashing, make sure we have not reduced the capacity below the current size.
+      if (newCapacity < capacity()) {
+        throw new IllegalStateException(
+            "Internal error: newCapacity < capacity, newCapacity="
+                + newCapacity
+                + ", capacity="
+                + capacity()
+                + ", _free="
+                + _free
+                + ", _size="
+                + _size
+                + ", _maxSize="
+                + _maxSize);
+      }
+
       rehash(newCapacity);
       computeMaxSize(capacity());
     }

--- a/src/main/java/io/deephaven/hash/KeyedObjectHash.java
+++ b/src/main/java/io/deephaven/hash/KeyedObjectHash.java
@@ -198,6 +198,14 @@ public class KeyedObjectHash<K, V> extends KHash implements Serializable, Iterab
           throw new IllegalStateException(
               "Internal error: h._free <= 2, newCapacity="
                   + newCapacity
+                  + ", capacity="
+                  + capacity()
+                  + ", _free="
+                  + _free
+                  + ", _size="
+                  + _size
+                  + ", _maxSize="
+                  + _maxSize
                   + ", h.capacity="
                   + h.capacity()
                   + ", h._free="

--- a/src/main/java/io/deephaven/hash/KeyedObjectHash.java
+++ b/src/main/java/io/deephaven/hash/KeyedObjectHash.java
@@ -192,6 +192,21 @@ public class KeyedObjectHash<K, V> extends KHash implements Serializable, Iterab
     h.storage = (V[]) new Object[newCapacity];
     for (V v : storage) {
       if (v != null && v != DELETED) {
+        // Before adding the next value, make sure we won't recurse by verifying h._free > 2 before
+        // the add
+        if (h._free <= 2) {
+          throw new IllegalStateException(
+              "Internal error: h._free <= 2, newCapacity="
+                  + newCapacity
+                  + ", h.capacity="
+                  + h.capacity()
+                  + ", h._free="
+                  + h._free
+                  + ", h._size="
+                  + h._size
+                  + ", h._maxSize="
+                  + h._maxSize);
+        }
         h.internalPut(v, NORMAL, null);
       }
     }


### PR DESCRIPTION
We identified some scenarios where the `rehash()` method can recurse. Rather than allowing that, the code will throw `IllegalStateException` with a descriptive message sharing the internal state of the hash data structure.